### PR TITLE
V1.4 - Final

### DIFF
--- a/add-customer-for-woocommerce.php
+++ b/add-customer-for-woocommerce.php
@@ -7,8 +7,8 @@
  * Contributors: dansart
  * Contributors URL: http://dev.dans-art.ch
  * Tags: woocommerce, customer, tools, helper
- * Version: 1.3.1
- * Stable tag: 1.3.1
+ * Version: 1.4
+ * Stable tag: 1.4
  * 
  * Requires at least: 5.5.3
  * Tested up to: 5.9

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Donate link: <https://paypal.me/dansart13>
 Tags: woocommerce, customer, tools, helper
 Requires at least: 5.5.3
 Tested up to: 5.9
-Stable tag: 1.3.1
+Stable tag: 1.4
 License: GPLv3 or later
 License URI: <http://www.gnu.org/licenses/gpl-2.0.html>
 WC requires at least: 4.7.0
@@ -56,6 +56,12 @@ Does the new user get a notification of the created account?
 - No, not per default. It can be enabled on the settings page. The Email will send the login credentials including a random password to the customer.
 
 == Changelog ==
+= [1.4] 2022-02-08 =
+
+* Added: Option to set the sender email
+* Added: Option to set subject of the new customer email
+* Added: New tab at the settings page to preview the loaded template (add-account)
+
 = [1.3.1] 2022-02-08 =
 
 * Fixed: Wordpress.org translations did not get loaded.

--- a/style/admin-style.css
+++ b/style/admin-style.css
@@ -24,3 +24,24 @@
     margin-top: 0.5em;
 }
 
+.wac_text_input.text-input td{
+    width: 95%;
+}
+
+.wac-options-tab .main_content .message{
+    background-color: white;
+}
+
+.wac-options-tab #load_location_container,
+.wac-options-tab .main_content,
+.wac-options-tab .subject_content{
+    margin: 1rem 0;
+}
+
+@media (min-width: 782px) {
+    .wac_text_input.text-input,
+    .wac_text_input.text-input input{
+        width: 100%;
+        max-width: 666px;
+    }
+}

--- a/templates/backend/backend-options-page-main.php
+++ b/templates/backend/backend-options-page-main.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This Template renders the backend page for the main settings.
+ * Wordpress Backend -> Settings -> Add Customer Settings
+ * 
+ * @version 1.4
+ */
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
+}
+
+?>
+
+
+<form id='wac_options_page' action="options.php" method="post"  enctype="multipart/form-data">
+    <?php
+
+    settings_fields('wac_general_options'); 
+    do_settings_sections('wac_general_options');
+    
+    submit_button();
+    ?>
+</form>

--- a/templates/backend/backend-options-page-template.php
+++ b/templates/backend/backend-options-page-template.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This Template renders the backend page of the template preview.
+ * Wordpress Backend -> Settings -> Add Customer Settings -> [Tab]Template
+ * 
+ * @version 1.4
+ */
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
+}
+$wac = new woo_add_customer;
+$blog_name = get_bloginfo('name');
+$blog_name = html_entity_decode($blog_name, ENT_QUOTES, 'UTF-8');
+$user = wp_get_current_user();
+
+$message = $this->load_template_to_var('new-account', 'email/', $user->user_email, $user->display_name, 'sup3r5ecur3p@ssw0rd', $blog_name);
+$subject = $wac->get_mail_subject('wac_template_subject_add_account');
+
+?>
+<div id="template_preview_container">
+    <div class="subject_content">
+        <div><?php echo __('Email Subject:', 'wac'); ?></div>
+        <div class="subject"><strong><?php echo $subject; ?></strong></div>
+    </div>
+    <div class="main_content">
+        <div><?php echo __('Email Content:', 'wac'); ?></div>
+        <div class="message"><?php echo $message; ?></div>
+    </div>
+</div>
+<div id="load_location_container">
+    <?php echo __('Template loaded from:', 'wac') . ' ' . $wac->get_template_location('add-account', 'email/');  ?>
+
+</div>
+<div id="reload_container">
+    <form id='wac_options_page' action="options-general.php?page=wac-options&tab=template" method="post" enctype="multipart/form-data">
+        <?php
+        submit_button(__('Reload template', 'wac'));
+        ?>
+    </form>
+</div>

--- a/templates/backend/backend-options-page.php
+++ b/templates/backend/backend-options-page.php
@@ -1,25 +1,39 @@
 <?php
+
 /**
  * This Template renders the backend page of the settings.
  * Wordpress Backend -> Settings -> Add Customer Settings
  * 
- * @version 1.1
+ * @version 1.4
  */
 
 if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
 }
-
+$wac = new woo_add_customer;
+$this->wac_enqueue_admin_style();
 ?>
-<h2><?php echo __('Add Customer for Woocommerce Settings','wac');?></h2>
 
+<h2><?php echo __('Add Customer for Woocommerce Settings', 'wac'); ?></h2>
 
-<form id='wac_options_page' action="options.php" method="post"  enctype="multipart/form-data">
+<?php
+$current_tab = (isset($_GET['tab'])) ? $_GET['tab'] : null;
+?>
+
+<nav class="nav-tab-wrapper">
+    <a href="?page=wac-options" class="nav-tab <?php if ($current_tab === null) {echo 'nav-tab-active';} ?>"><?php echo __('General', 'wac'); ?></a>
+    <a href="?page=wac-options&tab=template" class="nav-tab <?php if ($current_tab === 'template') {echo 'nav-tab-active';} ?>"><?php echo __('Template', 'wac'); ?></a>
+</nav>
+
+<div class="wac-options-tab tab-content">
     <?php
-
-    settings_fields('wac_general_options'); 
-    do_settings_sections('wac_general_options');
-    
-    submit_button();
+    switch ($current_tab) {
+        case 'template':
+            echo $wac->load_template_to_var('backend-options-page-template', 'backend/');
+            break;
+        default:
+            echo $wac->load_template_to_var('backend-options-page-main', 'backend/');
+            break;
+    }
     ?>
-</form>
+</div>

--- a/templates/email/new-account.php
+++ b/templates/email/new-account.php
@@ -4,6 +4,9 @@
  * This email is getting send, when a new user is created by Add Customer for Woocommerce.
  * For this to happen, you have to activate the option in Wordpress Backend -> Settings -> Add Customer Settings -> Send Notifications to new user
  * 
+ * This file can be overridden by a template file in the theme / child-theme folder.
+ * Copy this file to: /wp-content/themes/[theme/child-theme]/woocommerce/add-customer/email/add-account.php 
+ * 
  * Author: Dan's Art
  * Author URI: http://dev.dans-art.ch
  */


### PR DESCRIPTION
Version 1.4 Final

Changelog
= [1.4] 2022-02-22 =

* Added: Option to set the sender email
* Added: Option to set the subject of the new customer email
* Added: New tab at the settings page to preview the loaded template (new-account)
* The plain password got replaced by a password reset link to improve security.
* Fixed: Email to the new customer will only be sent if the email is not generated by the plugin.
* Added 18 new language strings. 4 obsolete strings removed.