### PR TITLE
hotfix for undefined function get_plugin_data after upgrade to 1.4

### DIFF
--- a/include/tools/helper.php
+++ b/include/tools/helper.php
@@ -22,7 +22,7 @@ class woo_add_customer_helper
      */
     public function load_version()
     {
-        $plugin_meta = get_plugin_data($this->plugin_path . 'add-customer-for-woocommerce.php');
+        $plugin_meta = get_file_data($this->plugin_path . 'add-customer-for-woocommerce.php', array('Version'), 'plugin');
         $this->version = (!empty($plugin_meta['Version'])) ? $plugin_meta['Version'] : "000";
     }
 


### PR DESCRIPTION
Why the change?
After upgrading from v1.31.1 to v1.4, my Wordpress 5.9.1 Bitnami installation began to crash with critical errors of "undefined function get_plugin_data() from helper.php line 25"

I updated load_version() to use get_file_data instead of get_plugin_data, which resolved the issue for my installation. Opening this request as it could be helpful if other installations experiences this issue.
